### PR TITLE
adding automated dockerhub build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 # files not to be included in docker build
 
-.git*
 config*.yaml
 config*.yml

--- a/Dockerfile.autobuild
+++ b/Dockerfile.autobuild
@@ -1,0 +1,34 @@
+#Builder stage to create the binary
+FROM golang:1.9.2-alpine3.7 as builder
+
+RUN apk add --update \
+    curl git;
+
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+
+RUN curl https://glide.sh/get | sh
+
+ADD . /go/src/github.com/target/portauthority
+WORKDIR /go/src/github.com/target/portauthority
+
+RUN glide install -v
+
+RUN VERSION=$(git for-each-ref refs/tags --sort=-taggerdate --format='%(refname:short)' --count=1) && echo version=$VERSION; \
+  if [ "$VERSION" == "" ] || [ -z "$VERSION" ]; \
+  then echo "DEV BUILD" && go build -ldflags "-X main.appVersion=dev" -o portauthority; \
+  else echo "TAG BUILD" && go build -ldflags "-X main.appVersion=$VERSION" -o portauthority; \
+  fi
+
+
+#Final image stage
+FROM alpine:3.7
+
+#Make sure we are patching all packages
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache \
+        ca-certificates \
+    && update-ca-certificates
+
+COPY --from=builder /go/src/github.com/target/portauthority/portauthority /usr/bin/
+ENTRYPOINT ["portauthority"]

--- a/NOTICE2
+++ b/NOTICE2
@@ -1,0 +1,209 @@
+This file contains the open source licenses for the following open source components in coreos/clair:
+
+1. coreos/clair (commit 3ec262dd51466100b44910b60308e46b00f2a097)
+-------------------------------------------------------------------------------------------------------
+
+1. coreos/clair (commit 3ec262dd51466100b44910b60308e46b00f2a097)
+https://github.com/coreos/clair
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/target/portauthority.svg?branch=master)](https://travis-ci.org/target/portauthority/builds)
+
 ## Introduction
 
 Port Authority is an API service that delivers component based vulnerability assessments for Docker images at time of build and in run-time environments. Port Authority also provides Developers additional customizable offerings to assist with the automated audit and governance of their containers.
@@ -22,13 +24,23 @@ In the backend Port Authority utilizes the open source static analysis tool [Cla
 
    `eval $(minikube docker-env)`
 
+2. Deploy official Port Authority stack:
+
+   `make deploy-minikube`
+
+(Optional). Local developer build stack:
+
+1. Use Minikube Docker:
+
+   `eval $(minikube docker-env)`
+
 2. Get all Glide dependancies:
 
    `make deps`
 
-3. Build & deploy:
+3. Deploy official Port Authority stack:
 
-   `make deploy-minikube`
+   `make deploy-minikube-dev`
 
 ## Optional Configuration
 Different configuration adjustments can be made to the Port Authority deployment here: [minikube/portauthority/portauthority/config.yml](minikube/portauthority/portauthority/config.yml)
@@ -73,3 +85,5 @@ Found something that doesn't seem right or have a feature request? [Please open 
 [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.txt)
 
 &copy;2018 Target Brands, Inc.
+
+**Credit [Renee French](http://reneefrench.blogspot.com/) for original golang gopher

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -31,10 +31,10 @@ func init() {
 }
 
 // App func init
-func App() *cli.App {
+func App(appVersion string) *cli.App {
 	app := cli.NewApp()
 	app.Name = "Port Authority"
-	app.Version = "v0.4.0"
+	app.Version = appVersion
 	app.Usage = ""
 	app.Flags = []cli.Flag{}
 

--- a/main.go
+++ b/main.go
@@ -11,8 +11,10 @@ import (
 	_ "github.com/target/portauthority/pkg/datastore/pgsql"
 )
 
+var appVersion string
+
 func main() {
-	app := cmd.App()
+	app := cmd.App(appVersion)
 	app.Run(os.Args)
 
 }

--- a/minikube/portauthority/portauthority-local/config.yml
+++ b/minikube/portauthority/portauthority-local/config.yml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portauthority-config
+data:
+  config.yml: |
+    # The values specified here are the default values that Port Authority uses if no configuration file is specified or if the keys are not defined.
+    portauthority:
+      database:
+        # Database driver
+        type: pgsql
+        options:
+          # PostgreSQL Connection string
+          # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+
+          # This can be the same or separate DB as your clair database.
+          source: host=portauthority-postgres-service port=5432 sslmode=disable statement_timeout=60000
+
+          # Number of elements kept in the cache
+          # Values unlikely to change are cached in order to save prevent needless roundtrips to the database.
+          cachesize: 16384
+      api:
+        # API server port
+        port: 6100
+
+        # Health server port
+        # This is an unencrypted endpoint useful for load balancers to check to healthiness of the port authority server.
+        healthport: 6101
+
+        # Deadline before an API request will respond with a 503
+        timeout: 900s
+
+        # Setting imagewebhookdefaultblock to true will set the imagewebhooks endpoint default behavior to block any images with policy violations.
+        # If it is set to false, a user can change enable the behavior by setting the portauthority-webhook anotation to true
+        imagewebhookdefaultblock: false
+
+        # URL of the Clair server Port Authority sends it's images/layers for scanning
+        # If running Clair is running in Minikube, change the path to the advertised service (e.g. http://clair-service:6100)
+        clairurl: http://clair-service:6060
+        clairtimeout: 900
+
+        ### Environment variables defined below are mapped to credentials used by the Kubneretes Crawler API (/v1/crawler/k8s)
+        ### A 'Scan: true' flag will invoke their usage
+        k8scrawlcredentials:
+          - url: "docker.io" #basic auth is empty UN and PW
+            username: ""
+            password: ""
+          - url: "gcr.io" #basic auth is empty UN and PW
+            username: ""
+            password: ""

--- a/minikube/portauthority/portauthority-local/deployment.yml
+++ b/minikube/portauthority/portauthority-local/deployment.yml
@@ -11,8 +11,8 @@ spec:
     spec:
       containers:
       - name: portauthority
-        image: target/portauthority:latest
-        imagePullPolicy: Always
+        image: portauthority:latest
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6100
         - containerPort: 6101

--- a/minikube/portauthority/portauthority-local/service.yml
+++ b/minikube/portauthority/portauthority-local/service.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: portauthority-service
+  name: portauthority-service
+spec:
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 6100
+      targetPort: 6100
+      nodePort: 31700
+      name: portauthority-port0
+    - port: 6101
+      protocol: TCP
+      targetPort: 6101
+      nodePort: 31701
+      name: portauthority-port1
+  selector:
+     app: portauthority-deployment


### PR DESCRIPTION
* creates automated dockerhub builds on tag releases
- latest tag is applied to stable versioned releases
- any tag with version-.* is a non-standard or pre-release build
- version applied to the binary

* deploy-minikube will now deploy the offical image into minikube instead of a local dev build
* local dev option is available with deploy-minikube-dev still
* adding a second notice of clair license