### PR TITLE
Scan registry using credentials embedded in the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Port Authority also supplies developers with customizable offerings to assist wi
 ## Optional Configuration
 Different configuration adjustments can be made to the Port Authority deployment here: [minikube/portauthority/portauthority/config.yml](minikube/portauthority/portauthority/config.yml)
 
-:white_check_mark: Add Docker Credentials used by the K8s Crawler scan feature
+:white_check_mark: Add Docker Credentials used by the K8s Crawler scan feature and when no credentials are present in a scan image request
 
 ```
 ### Environment variables defined below are mapped to credentials used by the Kubernetes Crawler API (/v1/crawler/k8s)

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ The POST route for the Image resource performs the analysis of an Image from the
 
 The Docker manifest is pulled from the registry and the proper layer path is sent to [Clair Layer API](https://github.com/coreos/clair/blob/master/Documentation/api_v1.md#post-layers) in the correct order.  The layer parent and child names are hashed with the image content digest to provide a unique name per layer so that the proper order can be maintained within the Clair database.
 
+When no registry credentials are available configuration will be checked for appropriate ones.
+
 #### Example Request
 
 ```


### PR DESCRIPTION
If there are no credentials in POST Image API call `portauthority` will look for them in `k8scrawlcredentials` part of the configuration file.

This PR solves issue https://github.com/target/portauthority/issues/21